### PR TITLE
Fix test imports and add vetting service stub

### DIFF
--- a/backend/core/use_cases/vetting_service.py
+++ b/backend/core/use_cases/vetting_service.py
@@ -1,0 +1,54 @@
+import pandas as pd
+from backend.core.infrastructure.yfinance_repository import YahooFinanceRepository
+from backend.core.infrastructure.economic_data_repository import EconomicDataRepository
+from backend.core.use_cases.categorization_service import CategorizationService
+from backend.core.entities.models import Company, InvestmentCandidate
+
+class VettingService:
+    def __init__(self):
+        self.yfinance_repo = YahooFinanceRepository()
+        self.economic_repo = EconomicDataRepository()
+        self.categorization_service = CategorizationService()
+
+    def vet_candidate(self, ticker: str) -> dict:
+        company = self.yfinance_repo.get_company_info(ticker)
+        data = self.yfinance_repo.get_all_data(ticker)
+        category = self.categorization_service.categorize(data)
+        lynch = self._vet_lynch_criteria(data['info'])
+        canslim = self._vet_canslim_criteria(data['info'], data)
+        return {
+            "ticker": ticker,
+            "company_name": company.name,
+            "category": category,
+            "lynch_criteria": lynch,
+            "canslim_criteria": canslim,
+        }
+
+    def _vet_lynch_criteria(self, info: dict) -> dict:
+        peg = info.get('pegRatio')
+        insider_count = info.get('netSharePurchaseActivity', {}).get('buyInfoCount', 0)
+        return {
+            "PEG Ratio": {
+                "pass": peg is not None and peg <= 1.5,
+                "value": peg,
+            },
+            "Insider Buying": {
+                "pass": insider_count > 0,
+                "value": insider_count,
+            },
+        }
+
+    def _vet_canslim_criteria(self, info: dict, data: dict) -> dict:
+        eps_growth = info.get('earningsQuarterlyGrowth', 0)
+        history = pd.DataFrame(data.get('history'))
+        if history.empty or history['High'].max() == 0 or history['Volume'].mean() == 0:
+            high_status = "0.00%"
+            volume_status = "0.00%"
+        else:
+            high_status = f"{(history['Close'].iloc[-1] / history['High'].max() - 1) * 100:.2f}%"
+            volume_status = f"{(history['Volume'].iloc[-1] / history['Volume'].mean() - 1) * 100:.2f}%"
+        return {
+            "Quarterly EPS Growth": {"pass": eps_growth > 0.25},
+            "52-Week High Status": {"value": high_status},
+            "Volume vs. Avg": {"value": volume_status},
+        }

--- a/backend/tests/__init__.py
+++ b/backend/tests/__init__.py
@@ -1,0 +1,3 @@
+import os
+import sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))

--- a/backend/tests/test_vetting_service.py
+++ b/backend/tests/test_vetting_service.py
@@ -1,21 +1,16 @@
 import unittest
 from unittest.mock import MagicMock, patch
-import os
-import sys
 from io import StringIO
 import pandas as pd
 
-# Add the src directory to the Python path
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'src'))
-
-from stock_selection_framework.application.services import VettingService
-from stock_selection_framework.domain.models import Company, InvestmentCandidate
+from backend.core.use_cases.vetting_service import VettingService
+from backend.core.entities.models import Company, InvestmentCandidate
 
 class TestVettingService(unittest.TestCase):
 
-    @patch('stock_selection_framework.infrastructure.yfinance_repository.YahooFinanceRepository')
-    @patch('stock_selection_framework.infrastructure.economic_data_repository.EconomicDataRepository')
-    @patch('stock_selection_framework.application.categorization_service.CategorizationService')
+    @patch('backend.core.infrastructure.yfinance_repository.YahooFinanceRepository')
+    @patch('backend.core.infrastructure.economic_data_repository.EconomicDataRepository')
+    @patch('backend.core.use_cases.categorization_service.CategorizationService')
     def test_vet_candidate_attractive(self, MockCategorizationService, MockEconomicDataRepository, MockYahooFinanceRepository):
         # Arrange
         mock_repo_instance = MockYahooFinanceRepository.return_value
@@ -57,9 +52,9 @@ class TestVettingService(unittest.TestCase):
         self.assertTrue(results["lynch_criteria"]["Insider Buying"]["pass"])
         self.assertTrue(results["canslim_criteria"]["Quarterly EPS Growth"]["pass"])
 
-    @patch('stock_selection_framework.infrastructure.yfinance_repository.YahooFinanceRepository')
-    @patch('stock_selection_framework.infrastructure.economic_data_repository.EconomicDataRepository')
-    @patch('stock_selection_framework.application.categorization_service.CategorizationService')
+    @patch('backend.core.infrastructure.yfinance_repository.YahooFinanceRepository')
+    @patch('backend.core.infrastructure.economic_data_repository.EconomicDataRepository')
+    @patch('backend.core.use_cases.categorization_service.CategorizationService')
     def test_vet_candidate_unattractive(self, MockCategorizationService, MockEconomicDataRepository, MockYahooFinanceRepository):
         # Arrange
         mock_repo_instance = MockYahooFinanceRepository.return_value
@@ -101,9 +96,9 @@ class TestVettingService(unittest.TestCase):
         self.assertFalse(results["lynch_criteria"]["Insider Buying"]["pass"])
         self.assertFalse(results["canslim_criteria"]["Quarterly EPS Growth"]["pass"])
 
-    @patch('stock_selection_framework.infrastructure.yfinance_repository.YahooFinanceRepository')
-    @patch('stock_selection_framework.infrastructure.economic_data_repository.EconomicDataRepository')
-    @patch('stock_selection_framework.application.categorization_service.CategorizationService')
+    @patch('backend.core.infrastructure.yfinance_repository.YahooFinanceRepository')
+    @patch('backend.core.infrastructure.economic_data_repository.EconomicDataRepository')
+    @patch('backend.core.use_cases.categorization_service.CategorizationService')
     def test_vet_canslim_criteria_edge_cases(self, MockCategorizationService, MockEconomicDataRepository, MockYahooFinanceRepository):
         # Arrange
         mock_yfinance_repo_instance = MockYahooFinanceRepository.return_value


### PR DESCRIPTION
## Summary
- add repository root to PYTHONPATH for tests
- provide a basic `VettingService` so tests import
- update vetting service tests to use `backend` package paths

## Testing
- `pytest backend/tests -q` *(fails: ValueError requiring FRED_API_KEY and ProxyError for yfinance)*

------
https://chatgpt.com/codex/tasks/task_b_6862b911e1048326a795b674263710cf