### PR TITLE
Improve UI components

### DIFF
--- a/web/frontend/src/components/Dashboard.js
+++ b/web/frontend/src/components/Dashboard.js
@@ -6,7 +6,7 @@ import FinalSelectionModal from './FinalSelectionModal';
 import SentimentAnalysisModal from './SentimentAnalysisModal';
 import FastGrowersVettingModal from './FastGrowersVettingModal';
 import TurnaroundsVettingModal from './TurnaroundsVettingModal';
-import { Box, Button, Grid, Typography } from '@mui/material';
+import { Box, Button, Grid, Typography, Container, Paper } from '@mui/material';
 
 const stepsConfig = [
   { id: 'idea_generation', name: 'Step 1: AI-Powered Idea Generation' },
@@ -421,7 +421,7 @@ const Dashboard = () => {
   }
 
   return (
-    <Box className="dashboard" sx={{ p: 2 }}>
+    <Container className="dashboard" sx={{ py: 2 }}>
       <Box component="header" className="dashboard-header" sx={{ display: 'flex', justifyContent: 'space-between', mb: 2 }}>
         <Typography variant="h4">Stock Analysis Workflow</Typography>
         <Button variant="contained" onClick={startAnalysis} disabled={analysisInProgress}>
@@ -440,16 +440,16 @@ const Dashboard = () => {
           </Grid>
         ))}
       </Grid>
-      <Box className="results" sx={{ mt: 4 }}>
+      <Paper className="results" sx={{ mt: 4, p: 2 }}>
         <Typography variant="h5" sx={{ mb: 2 }}>Final Selected Stocks</Typography>
         <Grid container spacing={2} className="stock-list">
-            {finalStocks.map(stock => (
-                <Grid item xs={12} sm={6} md={4} key={stock.ticker}>
-                  <StockCard stock={stock} onClick={() => handleStockClick(stock)} />
-                </Grid>
-            ))}
+          {finalStocks.map(stock => (
+            <Grid item xs={12} sm={6} md={4} key={stock.ticker}>
+              <StockCard stock={stock} onClick={() => handleStockClick(stock)} />
+            </Grid>
+          ))}
         </Grid>
-      </Box>
+      </Paper>
       {showFinalSelectionModal && (
         <FinalSelectionModal
           data={finalSelectionData}
@@ -474,7 +474,7 @@ const Dashboard = () => {
           onClose={handleCloseTurnaroundsVettingModal}
         />
       )}
-    </Box>
+    </Container>
   );
 };
 

--- a/web/frontend/src/components/FastGrowersVettingModal.css
+++ b/web/frontend/src/components/FastGrowersVettingModal.css
@@ -1,17 +1,8 @@
-.modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.7);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
-}
-
-.modal-content {
+.modal-content-box {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   background: white;
   padding: 30px;
   border-radius: 8px;
@@ -20,7 +11,6 @@
   max-height: 90vh;
   overflow-y: auto;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  position: relative;
 }
 
 .modal-content h2 {

--- a/web/frontend/src/components/FastGrowersVettingModal.js
+++ b/web/frontend/src/components/FastGrowersVettingModal.js
@@ -1,32 +1,38 @@
 import React from 'react';
+import { Modal, Box, Typography, Grid, Paper, Button } from '@mui/material';
+
 import './FastGrowersVettingModal.css';
 
 const FastGrowersVettingModal = ({ data, onClose }) => {
   if (!data) return null;
 
   return (
-    <div className="modal-overlay">
-      <div className="modal-content">
-        <h2>Rigorous Vetting (Fast Growers)</h2>
-        <div className="vetting-grid">
+    <Modal open={!!data} onClose={onClose}>
+      <Box className="modal-content-box">
+        <Typography variant="h6" sx={{ mb: 2 }}>Rigorous Vetting (Fast Growers)</Typography>
+        <Grid container spacing={2} className="vetting-grid">
           {data.map((stock, index) => (
-            <div key={index} className="vetting-item">
-              <h3>{stock.ticker}</h3>
-              <div className="vetting-results">
-                {stock.vetting_result && Object.entries(stock.vetting_result).map(([key, value]) => (
-                  <p key={key}>
-                    <strong>{key}:</strong> {typeof value === 'object' && value !== null ? 
-                      (value.pass !== undefined ? (value.pass ? 'Pass' : 'Fail') : value.score !== undefined ? value.score : JSON.stringify(value))
-                      : value}
-                  </p>
-                ))}
-              </div>
-            </div>
+            <Grid item xs={12} sm={6} key={index}>
+              <Paper className="vetting-item" sx={{ p: 2 }}>
+                <Typography variant="subtitle1" sx={{ mb: 1 }}>{stock.ticker}</Typography>
+                <div className="vetting-results">
+                  {stock.vetting_result && Object.entries(stock.vetting_result).map(([key, value]) => (
+                    <Typography key={key} variant="body2">
+                      <strong>{key}:</strong> {typeof value === 'object' && value !== null ?
+                        (value.pass !== undefined ? (value.pass ? 'Pass' : 'Fail') : value.score !== undefined ? value.score : JSON.stringify(value))
+                        : value}
+                    </Typography>
+                  ))}
+                </div>
+              </Paper>
+            </Grid>
           ))}
-        </div>
-        <button onClick={onClose} className="close-button">Close</button>
-      </div>
-    </div>
+        </Grid>
+        <Box textAlign="center" sx={{ mt: 3 }}>
+          <Button variant="contained" onClick={onClose}>Close</Button>
+        </Box>
+      </Box>
+    </Modal>
   );
 };
 

--- a/web/frontend/src/components/FinalSelectionModal.css
+++ b/web/frontend/src/components/FinalSelectionModal.css
@@ -1,17 +1,8 @@
-.modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.7);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
-}
-
-.modal-content {
+.modal-content-box {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   background: white;
   padding: 30px;
   border-radius: 8px;
@@ -20,7 +11,6 @@
   max-height: 90vh;
   overflow-y: auto;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  position: relative;
 }
 
 .modal-content h2 {

--- a/web/frontend/src/components/FinalSelectionModal.js
+++ b/web/frontend/src/components/FinalSelectionModal.js
@@ -1,25 +1,31 @@
 import React from 'react';
+import { Modal, Box, Typography, Grid, Paper, Button } from '@mui/material';
+
 import './FinalSelectionModal.css';
 
 const FinalSelectionModal = ({ data, onClose }) => {
   if (!data) return null;
 
   return (
-    <div className="modal-overlay">
-      <div className="modal-content">
-        <h2>Final Selection & Synthesis</h2>
-        <div className="stock-grid">
+    <Modal open={!!data} onClose={onClose}>
+      <Box className="modal-content-box">
+        <Typography variant="h6" sx={{ mb: 2 }}>Final Selection &amp; Synthesis</Typography>
+        <Grid container spacing={2} className="stock-grid">
           {data.map((stock, index) => (
-            <div key={index} className="stock-item">
-              <h3>{stock.company_name} ({stock.ticker})</h3>
-              <p><strong>Category:</strong> {stock.category}</p>
-              <p><strong>Investment Thesis:</strong> {stock.investment_thesis}</p>
-            </div>
+            <Grid item xs={12} sm={6} key={index}>
+              <Paper className="stock-item" sx={{ p: 2 }}>
+                <Typography variant="subtitle1" sx={{ mb: 1 }}>{stock.company_name} ({stock.ticker})</Typography>
+                <Typography variant="body2"><strong>Category:</strong> {stock.category}</Typography>
+                <Typography variant="body2"><strong>Investment Thesis:</strong> {stock.investment_thesis}</Typography>
+              </Paper>
+            </Grid>
           ))}
-        </div>
-        <button onClick={onClose} className="close-button">Close</button>
-      </div>
-    </div>
+        </Grid>
+        <Box textAlign="center" sx={{ mt: 3 }}>
+          <Button variant="contained" onClick={onClose}>Close</Button>
+        </Box>
+      </Box>
+    </Modal>
   );
 };
 

--- a/web/frontend/src/components/SentimentAnalysisModal.css
+++ b/web/frontend/src/components/SentimentAnalysisModal.css
@@ -1,17 +1,8 @@
-.modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.7);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
-}
-
-.modal-content {
+.modal-content-box {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   background: white;
   padding: 30px;
   border-radius: 8px;
@@ -20,7 +11,6 @@
   max-height: 90vh;
   overflow-y: auto;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  position: relative;
 }
 
 .modal-content h2 {

--- a/web/frontend/src/components/SentimentAnalysisModal.js
+++ b/web/frontend/src/components/SentimentAnalysisModal.js
@@ -1,25 +1,31 @@
 import React from 'react';
+import { Modal, Box, Typography, Grid, Paper, Button } from '@mui/material';
+
 import './SentimentAnalysisModal.css';
 
 const SentimentAnalysisModal = ({ data, onClose }) => {
   if (!data) return null;
 
   return (
-    <div className="modal-overlay">
-      <div className="modal-content">
-        <h2>News & Social Media Sentiment Analysis</h2>
-        <div className="sentiment-grid">
+    <Modal open={!!data} onClose={onClose}>
+      <Box className="modal-content-box">
+        <Typography variant="h6" sx={{ mb: 2 }}>News &amp; Social Media Sentiment Analysis</Typography>
+        <Grid container spacing={2} className="sentiment-grid">
           {data.map((stock, index) => (
-            <div key={index} className="sentiment-item">
-              <h3>{stock.ticker}</h3>
-              <p><strong>Sentiment Score:</strong> <span className={stock.sentiment_score > 0.5 ? 'positive' : stock.sentiment_score < -0.5 ? 'negative' : 'neutral'}>{stock.sentiment_score.toFixed(2)}</span></p>
-              <p><strong>Summary:</strong> {stock.summary}</p>
-            </div>
+            <Grid item xs={12} sm={6} key={index}>
+              <Paper className="sentiment-item" sx={{ p: 2 }}>
+                <Typography variant="subtitle1" sx={{ mb: 1 }}>{stock.ticker}</Typography>
+                <Typography variant="body2"><strong>Sentiment Score:</strong> <span className={stock.sentiment_score > 0.5 ? 'positive' : stock.sentiment_score < -0.5 ? 'negative' : 'neutral'}>{stock.sentiment_score.toFixed(2)}</span></Typography>
+                <Typography variant="body2"><strong>Summary:</strong> {stock.summary}</Typography>
+              </Paper>
+            </Grid>
           ))}
-        </div>
-        <button onClick={onClose} className="close-button">Close</button>
-      </div>
-    </div>
+        </Grid>
+        <Box textAlign="center" sx={{ mt: 3 }}>
+          <Button variant="contained" onClick={onClose}>Close</Button>
+        </Box>
+      </Box>
+    </Modal>
   );
 };
 

--- a/web/frontend/src/components/Step.js
+++ b/web/frontend/src/components/Step.js
@@ -1,5 +1,9 @@
 import React from 'react';
 import { Card, CardContent, Typography, Checkbox, FormControlLabel, Button, Box } from '@mui/material';
+import CheckCircleOutlineIcon from '@mui/icons-material/CheckCircleOutline';
+import HourglassEmptyIcon from '@mui/icons-material/HourglassEmpty';
+import AutorenewIcon from '@mui/icons-material/Autorenew';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
 
 const Step = ({ step, onToggleCache, onViewData, isClickable }) => {
   const { id, name, status, useCache } = step;
@@ -23,10 +27,20 @@ const Step = ({ step, onToggleCache, onViewData, isClickable }) => {
     failed: 'error.main'
   };
 
+  const statusIcons = {
+    pending: <HourglassEmptyIcon color="disabled" />,
+    running: <AutorenewIcon color="warning" />,
+    completed: <CheckCircleOutlineIcon color="success" />,
+    failed: <ErrorOutlineIcon color="error" />,
+  };
+
   return (
     <Card sx={{ borderLeft: 4, borderColor: borderColors[status] || 'grey.300' }}>
       <CardContent>
-        <Typography variant="h6">{name}</Typography>
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          {statusIcons[status]}
+          <Typography variant="h6" sx={{ ml: 1 }}>{name}</Typography>
+        </Box>
         <Box sx={{ mt: 1, display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
           <FormControlLabel
             control={

--- a/web/frontend/src/components/StockCard.js
+++ b/web/frontend/src/components/StockCard.js
@@ -1,28 +1,28 @@
 import React from 'react';
-import { Card, CardContent, Typography } from '@mui/material';
+import { Card, CardContent, Typography, CardActionArea, Box } from '@mui/material';
 
 const StockCard = ({ stock, onClick }) => {
   return (
-    <Card onClick={onClick} sx={{ cursor: 'pointer' }}>
-      <CardContent>
+    <Card sx={{ height: '100%' }}>
+      <CardActionArea onClick={onClick} sx={{ p: 2 }}>
         <Typography variant="h6">{stock.company_name} ({stock.ticker})</Typography>
         <Typography variant="body2" color="text.secondary">
-          Category: {stock.category}
+          {stock.category}
         </Typography>
         {stock.sector && stock.industry && (
           <Typography variant="body2" color="text.secondary">
             {stock.sector} | {stock.industry}
           </Typography>
         )}
-        <div className="metrics-summary">
+        <Box sx={{ mt: 1 }}>
           {stock.market_cap && (
             <Typography variant="body2">Market Cap: {stock.market_cap.toLocaleString()}</Typography>
           )}
           {stock.pe_ratio !== null && stock.pe_ratio !== undefined && (
             <Typography variant="body2">P/E Ratio: {stock.pe_ratio}</Typography>
           )}
-        </div>
-      </CardContent>
+        </Box>
+      </CardActionArea>
     </Card>
   );
 };

--- a/web/frontend/src/components/StockDetail.js
+++ b/web/frontend/src/components/StockDetail.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, Button, Typography, Card, CardContent } from '@mui/material';
+import { Box, Button, Typography, Card, CardContent, Grid } from '@mui/material';
 
 const StockDetail = ({ stock, onBack }) => {
   if (!stock) {
@@ -15,56 +15,66 @@ const StockDetail = ({ stock, onBack }) => {
   };
 
   return (
-    <Card className="stock-detail" sx={{ m: 'auto', maxWidth: 800 }}>
+    <Card className="stock-detail" sx={{ m: 'auto', maxWidth: 900 }}>
       <CardContent>
         <Button onClick={onBack} sx={{ mb: 2 }}>&larr; Back to List</Button>
-        <Box className="detail-header" sx={{ mb: 2 }}>
+        <Box sx={{ mb: 2 }}>
           <Typography variant="h5">{stock.info.symbol} - {stock.info.longName}</Typography>
           <Typography variant="subtitle1" color="text.secondary">
             {stock.info.sector} | {stock.info.industry}
           </Typography>
         </Box>
-        <Box className="detail-metrics">
-          <Typography variant="h6">Categorization</Typography>
-          <Typography><strong>Lynch Category (Rule-Based):</strong> {stock.category ?? 'N/A'}</Typography>
 
-          <Typography variant="h6" sx={{ mt: 2 }}>AI Evaluations</Typography>
-          <Box className="ai-evaluations" sx={{ mb: 2 }}>
+        <Grid container spacing={2}>
+          <Grid item xs={12}>
+            <Typography variant="h6">Categorization</Typography>
+            <Typography><strong>Lynch Category (Rule-Based):</strong> {stock.category ?? 'N/A'}</Typography>
+          </Grid>
+
+          <Grid item xs={12}>
+            <Typography variant="h6" sx={{ mt: 2 }}>AI Evaluations</Typography>
             <Typography variant="subtitle1">Investment Thesis</Typography>
             <Typography>{stock.investment_thesis ?? 'N/A'}</Typography>
             <Typography variant="subtitle1" sx={{ mt: 1 }}>Sentiment Analysis</Typography>
             <Typography>
-              <strong>Score:</strong>
-              {stock.sentiment_analysis?.score != null ? 
-              <span className={getSentimentColor(stock.sentiment_analysis.score)}>{stock.sentiment_analysis.score.toFixed(2)}</span> 
-              : 'N/A'}
+              <strong>Score:</strong> {stock.sentiment_analysis?.score != null ? (
+                <span className={getSentimentColor(stock.sentiment_analysis.score)}>{stock.sentiment_analysis.score.toFixed(2)}</span>
+              ) : 'N/A'}
             </Typography>
             <Typography><strong>Summary:</strong> {stock.sentiment_analysis?.summary ?? 'N/A'}</Typography>
-          </Box>
+          </Grid>
 
-          <Typography variant="h6" sx={{ mt: 2 }}>Vetting &amp; CAN SLIM Analysis</Typography>
-          <Box className="can-slim-analysis" sx={{ mb: 2 }}>
-            {stock.vetting_results && Object.entries(stock.vetting_results).map(([key, value]) => (
-              <Typography key={key}>
-                <strong>{key}:</strong> {typeof value === 'object' && value !== null ?
-                  (value.pass !== undefined ? (value.pass ? 'Pass' : 'Fail') : value.score !== undefined ? value.score : JSON.stringify(value))
-                  : value}
-              </Typography>
-            ))}
-          </Box>
+          <Grid item xs={12}>
+            <Typography variant="h6" sx={{ mt: 2 }}>Vetting &amp; CAN SLIM Analysis</Typography>
+            <Box sx={{ mb: 2 }}>
+              {stock.vetting_results && Object.entries(stock.vetting_results).map(([key, value]) => (
+                <Typography key={key}>
+                  <strong>{key}:</strong> {typeof value === 'object' && value !== null ?
+                    (value.pass !== undefined ? (value.pass ? 'Pass' : 'Fail') : value.score !== undefined ? value.score : JSON.stringify(value))
+                    : value}
+                </Typography>
+              ))}
+            </Box>
+          </Grid>
 
-          <Typography variant="h6" sx={{ mt: 2 }}>Company Overview</Typography>
-          <Typography>{stock.info?.longBusinessSummary ?? 'N/A'}</Typography>
+          <Grid item xs={12}>
+            <Typography variant="h6" sx={{ mt: 2 }}>Company Overview</Typography>
+            <Typography>{stock.info?.longBusinessSummary ?? 'N/A'}</Typography>
+          </Grid>
 
-          <Typography variant="h6" sx={{ mt: 2 }}>Financials</Typography>
-          <Typography><strong>Market Cap:</strong> {stock.info?.marketCap ? stock.info.marketCap.toLocaleString() : 'N/A'}</Typography>
-          <Typography><strong>Trailing P/E:</strong> {stock.info?.trailingPE != null ? stock.info.trailingPE.toFixed(2) : 'N/A'}</Typography>
-          <Typography><strong>Forward P/E:</strong> {stock.info?.forwardPE !== null ? stock.info.forwardPE.toFixed(2) : 'N/A'}</Typography>
-          <Typography><strong>Dividend Yield:</strong> {stock.info?.dividendYield !== null ? (stock.info.dividendYield * 100).toFixed(2) + '%' : 'N/A'}</Typography>
-          <Typography><strong>Beta:</strong> {stock.info?.beta !== null ? stock.info.beta.toFixed(2) : 'N/A'}</Typography>
-          <Typography><strong>52 Week High:</strong> {stock.info?.fiftyTwoWeekHigh !== null ? stock.info.fiftyTwoWeekHigh.toLocaleString() : 'N/A'}</Typography>
-          <Typography><strong>52 Week Low:</strong> {stock.info?.fiftyTwoWeekLow !== null ? stock.info.fiftyTwoWeekLow.toLocaleString() : 'N/A'}</Typography>
-        </Box>
+          <Grid item xs={12}>
+            <Typography variant="h6" sx={{ mt: 2 }}>Financials</Typography>
+            <Grid container spacing={1}>
+              <Grid item xs={6}><Typography><strong>Market Cap:</strong> {stock.info?.marketCap ? stock.info.marketCap.toLocaleString() : 'N/A'}</Typography></Grid>
+              <Grid item xs={6}><Typography><strong>Trailing P/E:</strong> {stock.info?.trailingPE != null ? stock.info.trailingPE.toFixed(2) : 'N/A'}</Typography></Grid>
+              <Grid item xs={6}><Typography><strong>Forward P/E:</strong> {stock.info?.forwardPE !== null ? stock.info.forwardPE.toFixed(2) : 'N/A'}</Typography></Grid>
+              <Grid item xs={6}><Typography><strong>Dividend Yield:</strong> {stock.info?.dividendYield !== null ? (stock.info.dividendYield * 100).toFixed(2) + '%' : 'N/A'}</Typography></Grid>
+              <Grid item xs={6}><Typography><strong>Beta:</strong> {stock.info?.beta !== null ? stock.info.beta.toFixed(2) : 'N/A'}</Typography></Grid>
+              <Grid item xs={6}><Typography><strong>52 Week High:</strong> {stock.info?.fiftyTwoWeekHigh !== null ? stock.info.fiftyTwoWeekHigh.toLocaleString() : 'N/A'}</Typography></Grid>
+              <Grid item xs={6}><Typography><strong>52 Week Low:</strong> {stock.info?.fiftyTwoWeekLow !== null ? stock.info.fiftyTwoWeekLow.toLocaleString() : 'N/A'}</Typography></Grid>
+            </Grid>
+          </Grid>
+        </Grid>
       </CardContent>
     </Card>
   );

--- a/web/frontend/src/components/TurnaroundsVettingModal.css
+++ b/web/frontend/src/components/TurnaroundsVettingModal.css
@@ -1,17 +1,8 @@
-.modal-overlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background: rgba(0, 0, 0, 0.7);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
-}
-
-.modal-content {
+.modal-content-box {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
   background: white;
   padding: 30px;
   border-radius: 8px;
@@ -20,7 +11,6 @@
   max-height: 90vh;
   overflow-y: auto;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  position: relative;
 }
 
 .modal-content h2 {

--- a/web/frontend/src/components/TurnaroundsVettingModal.js
+++ b/web/frontend/src/components/TurnaroundsVettingModal.js
@@ -1,32 +1,38 @@
 import React from 'react';
+import { Modal, Box, Typography, Grid, Paper, Button } from '@mui/material';
+
 import './TurnaroundsVettingModal.css';
 
 const TurnaroundsVettingModal = ({ data, onClose }) => {
   if (!data) return null;
 
   return (
-    <div className="modal-overlay">
-      <div className="modal-content">
-        <h2>Rigorous Vetting (Turnarounds)</h2>
-        <div className="vetting-grid">
+    <Modal open={!!data} onClose={onClose}>
+      <Box className="modal-content-box">
+        <Typography variant="h6" sx={{ mb: 2 }}>Rigorous Vetting (Turnarounds)</Typography>
+        <Grid container spacing={2} className="vetting-grid">
           {data.map((stock, index) => (
-            <div key={index} className="vetting-item">
-              <h3>{stock.ticker}</h3>
-              <div className="vetting-results">
-                {stock.vetting_result && Object.entries(stock.vetting_result).map(([key, value]) => (
-                  <p key={key}>
-                    <strong>{key}:</strong> {typeof value === 'object' && value !== null ? 
-                      (value.pass !== undefined ? (value.pass ? 'Pass' : 'Fail') : value.score !== undefined ? value.score : JSON.stringify(value))
-                      : value}
-                  </p>
-                ))}
-              </div>
-            </div>
+            <Grid item xs={12} sm={6} key={index}>
+              <Paper className="vetting-item" sx={{ p: 2 }}>
+                <Typography variant="subtitle1" sx={{ mb: 1 }}>{stock.ticker}</Typography>
+                <div className="vetting-results">
+                  {stock.vetting_result && Object.entries(stock.vetting_result).map(([key, value]) => (
+                    <Typography key={key} variant="body2">
+                      <strong>{key}:</strong> {typeof value === 'object' && value !== null ?
+                        (value.pass !== undefined ? (value.pass ? 'Pass' : 'Fail') : value.score !== undefined ? value.score : JSON.stringify(value))
+                        : value}
+                    </Typography>
+                  ))}
+                </div>
+              </Paper>
+            </Grid>
           ))}
-        </div>
-        <button onClick={onClose} className="close-button">Close</button>
-      </div>
-    </div>
+        </Grid>
+        <Box textAlign="center" sx={{ mt: 3 }}>
+          <Button variant="contained" onClick={onClose}>Close</Button>
+        </Box>
+      </Box>
+    </Modal>
   );
 };
 


### PR DESCRIPTION
## Summary
- tweak Step component icons and layout
- refine Dashboard layout with Container and Paper
- modernize stock card styling
- revamp stock detail view with grid layout
- update vetting and analysis modals to use Material UI

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_b_6862c4af0b888326afc6bbea525a10ea